### PR TITLE
Test suite stabilization

### DIFF
--- a/source/app/main.go
+++ b/source/app/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	health "person-service/healthcheck"
 	key_value "person-service/key_value"
+	person_attributes "person-service/person_attributes"
 	"strconv"
 	"time"
 
@@ -99,6 +100,7 @@ func main() {
 
 	healthHandler := health.NewHealthCheckHandler(queries)
 	keyValueHandler := key_value.NewKeyValueHandler(queries)
+	personAttributesHandler := person_attributes.NewPersonAttributesHandler(queries)
 
 	// Setup routes
 	e.GET("/health", healthHandler.Check)
@@ -107,6 +109,13 @@ func main() {
 	e.POST("/api/key-value", keyValueHandler.SetValue)
 	e.GET("/api/key-value/:key", keyValueHandler.GetValue)
 	e.DELETE("/api/key-value/:key", keyValueHandler.DeleteValue)
+
+	// Person attributes API routes
+	e.PUT("/persons/:personId/attributes", personAttributesHandler.CreateAttribute)
+	e.GET("/persons/:personId/attributes", personAttributesHandler.GetAllAttributes)
+	e.GET("/persons/:personId/attributes/:attributeId", personAttributesHandler.GetAttribute)
+	e.PUT("/persons/:personId/attributes/:attributeId", personAttributesHandler.UpdateAttribute)
+	e.DELETE("/persons/:personId/attributes/:attributeId", personAttributesHandler.DeleteAttribute)
 
 	// Configure server
 	e.Server = &http.Server{

--- a/source/app/person_attributes/person_attributes.go
+++ b/source/app/person_attributes/person_attributes.go
@@ -1,0 +1,511 @@
+package person_attributes
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"os"
+	db "person-service/internal/db/generated"
+	"strconv"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/labstack/echo/v4"
+)
+
+// Meta contains request metadata for tracing and auditing
+type Meta struct {
+	Caller  string `json:"caller"`
+	Reason  string `json:"reason"`
+	TraceID string `json:"traceId"`
+}
+
+// CreateAttributeRequest represents the request body for creating an attribute
+type CreateAttributeRequest struct {
+	Key   string `json:"key" validate:"required"`
+	Value string `json:"value"`
+	Meta  *Meta  `json:"meta"`
+}
+
+// UpdateAttributeRequest represents the request body for updating an attribute
+type UpdateAttributeRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Meta  *Meta  `json:"meta"`
+}
+
+// PersonAttributesHandler handles person attributes operations
+type PersonAttributesHandler struct {
+	queries       *db.Queries
+	encryptionKey string
+	keyVersion    int32
+}
+
+// NewPersonAttributesHandler creates a new instance of PersonAttributesHandler
+func NewPersonAttributesHandler(queries *db.Queries) *PersonAttributesHandler {
+	encryptionKey := os.Getenv("ENCRYPTION_KEY_1")
+	if encryptionKey == "" {
+		encryptionKey = "default-key-for-dev"
+	}
+	
+	return &PersonAttributesHandler{
+		queries:       queries,
+		encryptionKey: encryptionKey,
+		keyVersion:    1,
+	}
+}
+
+// CreateAttribute handles PUT /persons/:personId/attributes - creates or updates an attribute
+func (h *PersonAttributesHandler) CreateAttribute(c echo.Context) error {
+	// Parse person ID from path
+	personIDStr := c.Param("personId")
+	var personID pgtype.UUID
+	err := personID.Scan(personIDStr)
+	if err != nil {
+		// Return 404 for invalid UUID (treat as person not found)
+		return c.JSON(http.StatusNotFound, map[string]interface{}{
+			"message": "Person not found",
+		})
+	}
+
+	// Parse request body
+	var req CreateAttributeRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid request body",
+		})
+	}
+
+	// Validate required fields
+	if req.Key == "" {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Key is required",
+		})
+	}
+
+	// Validate meta is present
+	if req.Meta == nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Missing required field \"meta\"",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if person exists
+	_, err = h.queries.GetPersonById(ctx, personID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]interface{}{
+				"message": "Person not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to verify person",
+		})
+	}
+
+	// Create or update the attribute
+	_, err = h.queries.CreateOrUpdatePersonAttribute(ctx, db.CreateOrUpdatePersonAttributeParams{
+		PersonID:       personID,
+		AttributeKey:   req.Key,
+		AttributeValue: req.Value,
+		EncKey:         h.encryptionKey,
+		KeyVersion:     h.keyVersion,
+	})
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to create attribute: %v\n", err)
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to create attribute",
+		})
+	}
+
+	// Get the created attribute with decrypted value
+	attribute, err := h.queries.GetPersonAttribute(ctx, db.GetPersonAttributeParams{
+		PersonID:     personID,
+		AttributeKey: req.Key,
+		EncKey:       h.encryptionKey,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to retrieve attribute",
+		})
+	}
+
+	// Build response
+	response := map[string]interface{}{
+		"id":    attribute.ID,
+		"key":   attribute.AttributeKey,
+		"value": string(attribute.AttributeValue),
+	}
+
+	if attribute.CreatedAt.Valid {
+		response["createdAt"] = attribute.CreatedAt.Time
+	}
+	if attribute.UpdatedAt.Valid {
+		response["updatedAt"] = attribute.UpdatedAt.Time
+	}
+
+	// Always return 201 Created for this endpoint, even if it's an upsert
+	// This is because from the client's perspective, they're creating/setting an attribute
+	return c.JSON(http.StatusCreated, response)
+}
+
+// GetAllAttributes handles GET /persons/:personId/attributes - retrieves all attributes for a person
+func (h *PersonAttributesHandler) GetAllAttributes(c echo.Context) error {
+	// Parse person ID from path
+	personIDStr := c.Param("personId")
+	var personID pgtype.UUID
+	err := personID.Scan(personIDStr)
+	if err != nil {
+		// Return 404 for invalid UUID (treat as person not found)
+		return c.JSON(http.StatusNotFound, map[string]interface{}{
+			"message": "Person not found",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if person exists
+	_, err = h.queries.GetPersonById(ctx, personID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]interface{}{
+				"message": "Person not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to verify person",
+		})
+	}
+
+	// Get all attributes for the person
+	attributes, err := h.queries.GetAllPersonAttributes(ctx, db.GetAllPersonAttributesParams{
+		PersonID: personID,
+		EncKey:   h.encryptionKey,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to retrieve attributes",
+		})
+	}
+
+	// Build response array
+	response := make([]map[string]interface{}, 0, len(attributes))
+	for _, attr := range attributes {
+		item := map[string]interface{}{
+			"id":    attr.ID,
+			"key":   attr.AttributeKey,
+			"value": string(attr.AttributeValue),
+		}
+		if attr.CreatedAt.Valid {
+			item["createdAt"] = attr.CreatedAt.Time
+		}
+		if attr.UpdatedAt.Valid {
+			item["updatedAt"] = attr.UpdatedAt.Time
+		}
+		response = append(response, item)
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// GetAttribute handles GET /persons/:personId/attributes/:attributeId - retrieves a specific attribute
+func (h *PersonAttributesHandler) GetAttribute(c echo.Context) error {
+	// Parse person ID from path
+	personIDStr := c.Param("personId")
+	var personID pgtype.UUID
+	err := personID.Scan(personIDStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid person ID format",
+		})
+	}
+
+	// Parse attribute ID from path
+	attributeIDStr := c.Param("attributeId")
+	attributeID, err := strconv.ParseInt(attributeIDStr, 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid attribute ID format",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if person exists
+	_, err = h.queries.GetPersonById(ctx, personID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]interface{}{
+				"message": "Person not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to verify person",
+		})
+	}
+
+	// Get all attributes and find the one with matching ID
+	attributes, err := h.queries.GetAllPersonAttributes(ctx, db.GetAllPersonAttributesParams{
+		PersonID: personID,
+		EncKey:   h.encryptionKey,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to retrieve attributes",
+		})
+	}
+
+	// Find the attribute with matching ID
+	var foundAttr *db.GetAllPersonAttributesRow
+	for _, attr := range attributes {
+		if attr.ID == int32(attributeID) {
+			foundAttr = &attr
+			break
+		}
+	}
+
+	if foundAttr == nil {
+		return c.JSON(http.StatusNotFound, map[string]interface{}{
+			"message": "Attribute not found",
+		})
+	}
+
+	// Build response
+	response := map[string]interface{}{
+		"id":    foundAttr.ID,
+		"key":   foundAttr.AttributeKey,
+		"value": string(foundAttr.AttributeValue),
+	}
+	if foundAttr.CreatedAt.Valid {
+		response["createdAt"] = foundAttr.CreatedAt.Time
+	}
+	if foundAttr.UpdatedAt.Valid {
+		response["updatedAt"] = foundAttr.UpdatedAt.Time
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// UpdateAttribute handles PUT /persons/:personId/attributes/:attributeId - updates a specific attribute
+func (h *PersonAttributesHandler) UpdateAttribute(c echo.Context) error {
+	// Parse person ID from path
+	personIDStr := c.Param("personId")
+	var personID pgtype.UUID
+	err := personID.Scan(personIDStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid person ID format",
+		})
+	}
+
+	// Parse attribute ID from path
+	attributeIDStr := c.Param("attributeId")
+	attributeID, err := strconv.ParseInt(attributeIDStr, 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid attribute ID format",
+		})
+	}
+
+	// Parse request body
+	var req UpdateAttributeRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid request body",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if person exists
+	_, err = h.queries.GetPersonById(ctx, personID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]interface{}{
+				"message": "Not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to verify person",
+		})
+	}
+
+	// Get all attributes and find the one with matching ID to get the key
+	attributes, err := h.queries.GetAllPersonAttributes(ctx, db.GetAllPersonAttributesParams{
+		PersonID: personID,
+		EncKey:   h.encryptionKey,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to retrieve attributes",
+		})
+	}
+
+	// Find the attribute with matching ID
+	var existingKey string
+	found := false
+	for _, attr := range attributes {
+		if attr.ID == int32(attributeID) {
+			existingKey = attr.AttributeKey
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return c.JSON(http.StatusNotFound, map[string]interface{}{
+			"message": "Attribute not found",
+		})
+	}
+
+	// Determine which key to use: if new key is provided, use it; otherwise use existing key
+	keyToUse := existingKey
+	if req.Key != "" {
+		keyToUse = req.Key
+	}
+
+	// If the key changed, we need to delete the old one first
+	if req.Key != "" && req.Key != existingKey {
+		err = h.queries.DeletePersonAttribute(ctx, db.DeletePersonAttributeParams{
+			PersonID:     personID,
+			AttributeKey: existingKey,
+		})
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+				"message": "Failed to update attribute key",
+			})
+		}
+	}
+
+	// Update the attribute (or create with new key)
+	_, err = h.queries.CreateOrUpdatePersonAttribute(ctx, db.CreateOrUpdatePersonAttributeParams{
+		PersonID:       personID,
+		AttributeKey:   keyToUse,
+		AttributeValue: req.Value,
+		EncKey:         h.encryptionKey,
+		KeyVersion:     h.keyVersion,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to update attribute",
+		})
+	}
+
+	// Get the updated attribute
+	attribute, err := h.queries.GetPersonAttribute(ctx, db.GetPersonAttributeParams{
+		PersonID:     personID,
+		AttributeKey: keyToUse,
+		EncKey:       h.encryptionKey,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to retrieve updated attribute",
+		})
+	}
+
+	// Build response
+	response := map[string]interface{}{
+		"id":    attribute.ID,
+		"key":   attribute.AttributeKey,
+		"value": string(attribute.AttributeValue),
+	}
+	if attribute.CreatedAt.Valid {
+		response["createdAt"] = attribute.CreatedAt.Time
+	}
+	if attribute.UpdatedAt.Valid {
+		response["updatedAt"] = attribute.UpdatedAt.Time
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// DeleteAttribute handles DELETE /persons/:personId/attributes/:attributeId - deletes a specific attribute
+func (h *PersonAttributesHandler) DeleteAttribute(c echo.Context) error {
+	// Parse person ID from path
+	personIDStr := c.Param("personId")
+	var personID pgtype.UUID
+	err := personID.Scan(personIDStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid person ID format",
+		})
+	}
+
+	// Parse attribute ID from path
+	attributeIDStr := c.Param("attributeId")
+	attributeID, err := strconv.ParseInt(attributeIDStr, 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"message": "Invalid attribute ID format",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if person exists
+	_, err = h.queries.GetPersonById(ctx, personID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]interface{}{
+				"message": "Not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to verify person",
+		})
+	}
+
+	// Get all attributes and find the one with matching ID to get the key
+	attributes, err := h.queries.GetAllPersonAttributes(ctx, db.GetAllPersonAttributesParams{
+		PersonID: personID,
+		EncKey:   h.encryptionKey,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to retrieve attributes",
+		})
+	}
+
+	// Find the attribute with matching ID
+	var keyToDelete string
+	found := false
+	for _, attr := range attributes {
+		if attr.ID == int32(attributeID) {
+			keyToDelete = attr.AttributeKey
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return c.JSON(http.StatusNotFound, map[string]interface{}{
+			"message": "Attribute not found",
+		})
+	}
+
+	// Delete the attribute
+	err = h.queries.DeletePersonAttribute(ctx, db.DeletePersonAttributeParams{
+		PersonID:     personID,
+		AttributeKey: keyToDelete,
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"message": "Failed to delete attribute",
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"message": "Attribute deleted successfully",
+	})
+}

--- a/specs/steps/person_attributes.steps.js
+++ b/specs/steps/person_attributes.steps.js
@@ -34,6 +34,13 @@ const feature = loadFeature('../features/person_attributes.feature', {
  * @returns {Object} Parsed object with key-value pairs
  */
 function parseTableToObject(table) {
+  // jest-cucumber passes table data as an array of objects
+  // If table is already an object array, return the first object
+  if (table && table.length > 0 && typeof table[0] === 'object' && !Array.isArray(table[0])) {
+    return table[0];
+  }
+  
+  // Fallback to original format (2D array)
   const headers = table[0];
   const values = table[1];
   const result = {};
@@ -49,6 +56,13 @@ function parseTableToObject(table) {
  * @returns {Array} Array of objects
  */
 function parseTableToArray(table) {
+  // jest-cucumber passes table data as an array of objects
+  // If table is already an object array, return it as-is
+  if (table && table.length > 0 && typeof table[0] === 'object' && !Array.isArray(table[0])) {
+    return table;
+  }
+  
+  // Fallback to original format (2D array)
   const headers = table[0];
   const result = [];
   for (let i = 1; i < table.length; i++) {


### PR DESCRIPTION
Implemented person attributes API and fixed test table parsing to resolve all `make test` failures.

The `person_attributes.steps.js` was updated to correctly interpret table data passed by `jest-cucumber`, which differed from the original 2D array format. This enabled the successful implementation and testing of the new person attributes API, including specific error handling (e.g., 404 for non-existent persons/attributes, 201 for upsert) and mandatory `meta` field validation, as required by the tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-75cb2267-649e-48ac-ac22-299fc0dc8fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75cb2267-649e-48ac-ac22-299fc0dc8fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

